### PR TITLE
Fix JSON schema validation error with Claude Code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: 'perplexity_search_web',
         description: 'Search the web using Perplexity AI with recency filtering',
         inputSchema: {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
           type: 'object',
           properties: {
             query: {
@@ -48,56 +49,46 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             frequency_penalty: {
               type: 'number',
-              description: 'Multiplicative penalty for new tokens based on their frequency in the text to avoid repetition. Mutually exclusive with the presence_penalty parameter.',
-              required: false
+              description: 'Multiplicative penalty for new tokens based on their frequency in the text to avoid repetition. Mutually exclusive with the presence_penalty parameter.'
             },
             max_tokens: {
               type: 'integer',
-              description: 'The maximum number of tokens to generate. Sum of max_tokens and prompt tokens should not exceed the model\'s context window limit.',
-              required: false
+              description: 'The maximum number of tokens to generate. Sum of max_tokens and prompt tokens should not exceed the model\'s context window limit.'
             },
             model: {
               type: 'string',
-              description: 'The name of the model to use for generating completions. Options include sonar, sonar-pro, and other models listed at https://docs.perplexity.ai/guides/model-cards',
-              required: false
+              description: 'The name of the model to use for generating completions. Options include sonar, sonar-pro, and other models listed at https://docs.perplexity.ai/guides/model-cards'
             },
             presence_penalty: {
               type: 'number',
-              description: 'Penalty for new tokens based on their current presence in the text, encouraging topic variety. Mutually exclusive with the frequency_penalty parameter.',
-              required: false
+              description: 'Penalty for new tokens based on their current presence in the text, encouraging topic variety. Mutually exclusive with the frequency_penalty parameter.'
             },
             return_citations: {
               type: 'boolean',
               description: 'Whether to include citations in the model\'s response.',
-              default: true,
-              required: false
+              default: true
             },
             return_images: {
               type: 'boolean',
               description: 'Whether to include images in the model\'s response.',
-              default: false,
-              required: false
+              default: false
             },
             stream: {
               type: 'boolean',
               description: 'Whether to stream the response incrementally using server-sent events.',
-              default: false,
-              required: false
+              default: false
             },
             temperature: {
               type: 'number',
-              description: 'Controls generation randomness, with 0 being deterministic and values approaching 2 being more random.',
-              required: false
+              description: 'Controls generation randomness, with 0 being deterministic and values approaching 2 being more random.'
             },
             top_k: {
               type: 'integer',
-              description: 'Limits the number of high-probability tokens to consider for generation. Set to 0 to disable.',
-              required: false
+              description: 'Limits the number of high-probability tokens to consider for generation. Set to 0 to disable.'
             },
             top_p: {
               type: 'number',
-              description: 'Nucleus sampling threshold, controlling the token selection pool based on cumulative probability.',
-              required: false
+              description: 'Nucleus sampling threshold, controlling the token selection pool based on cumulative probability.'
             }
           },
           required: ['query']


### PR DESCRIPTION
## Summary
- Fixed JSON schema validation error when using the MCP server with Claude Code
- Updated schema to comply with JSON Schema draft 2020-12 specification
- Removed invalid `required: false` properties from individual fields

## Problem
The MCP server was throwing a validation error when used with Claude Code:
```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"tools.33.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12"}}
```

## Solution
1. Added `$schema` declaration for JSON Schema draft 2020-12
2. Removed all `required: false` properties from individual fields (not valid in JSON Schema)
3. Kept the correct `required: ['query']` array at the object level

## Testing
- Built the package successfully with `npm run build`
- Verified the compiled output includes the schema changes
- The schema now complies with JSON Schema draft 2020-12 specification

Fixes #1